### PR TITLE
Add config server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,23 @@ Use dockernet or any other name to specify the lookup name for docker-machine ho
  - Set docker external IP
  
 Edit `api-gateway/src/config/docker.json` and set `api.gateway.http.address.external` property to `dockernet`.
-If you choose to use a different lookup name than you'll have to update `docker/docker-compose.yml` line `- "dockernet:${EXTERNAL_IP}"` and replace __dockernet__ with your hostname of choice.   
+If you choose to use a different lookup name than you'll have to update `docker/docker-compose.yml` line `- "dockernet:${EXTERNAL_IP}"` and replace __dockernet__ with your hostname of choice.
+
+In addition, the following docker-machine properties need to be set for ELK stack to work:
+
+```
+docker-machine ssh
+sudo sysctl net.ipv4.ip_forward
+sudo sysctl -w vm.max_map_count=262144
+```
+
+Memory might be an issue as well. If applications start failing because memory could not be allocated, then you'll need to increase your docker-machine memory using the following steps:
+
+ 1. Stop docker-machine: `docker-machine stop`
+ 1. Start VirtualBox
+ 1. Select `default` VM
+ 1. Choose Settings->System
+ 1. Increase `Base Memory` (I had to increase from 2048 to 4096 MB) 
   
 ## Build/Run
 

--- a/account-microservice/Dockerfile
+++ b/account-microservice/Dockerfile
@@ -13,4 +13,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar account-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar account-microservice-fat.jar -cluster -conf docker.json"]

--- a/account-microservice/src/main/resources/log4j2.xml
+++ b/account-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="account-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/account-microservice/src/main/resources/log4j2.xml
+++ b/account-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="account-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -13,4 +13,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar api-gateway-fat.jar -cluster -ha -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar api-gateway-fat.jar -cluster -ha -conf docker.json"]

--- a/api-gateway/src/main/resources/log4j2.xml
+++ b/api-gateway/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="api-gateway"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/api-gateway/src/main/resources/log4j2.xml
+++ b/api-gateway/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="api-gateway"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/cache-infrastructure/Dockerfile
+++ b/cache-infrastructure/Dockerfile
@@ -10,4 +10,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar cache-infrastructure-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar cache-infrastructure-fat.jar -cluster -conf docker.json"]

--- a/cache-infrastructure/src/main/resources/log4j2.xml
+++ b/cache-infrastructure/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="cache-infrastructure"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/cache-infrastructure/src/main/resources/log4j2.xml
+++ b/cache-infrastructure/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="cache-infrastructure"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/docker/config-server/inventory-microservice/docker.json
+++ b/docker/config-server/inventory-microservice/docker.json
@@ -1,0 +1,7 @@
+{
+  "api.name": "inventory",
+  "redis.host": "redis",
+  "inventory.http.address": "0.0.0.0",
+  "inventory.http.port": 8086,
+  "log4j.config.uri": "http://configserver:80/inventory-microservice/log4j2-gelf.xml"
+}

--- a/docker/config-server/inventory-microservice/log4j2-console.xml
+++ b/docker/config-server/inventory-microservice/log4j2-console.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+
+        <Async name="console_async">
+            <AppenderRef ref="console"/>
+        </Async>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="console_async"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/docker/config-server/inventory-microservice/log4j2-gelf.xml
+++ b/docker/config-server/inventory-microservice/log4j2-gelf.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="inventory-microservice"/>
+        </Gelf>
+
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="gelf_async"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,61 +22,104 @@ services:
     image: redis:latest
     expose:
       - "6379"
+  elasticsearch:
+    image: elasticsearch
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    command: elasticsearch
+    environment:
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+  logstash:
+    image: logstash
+    ports:
+      - "12201:12201/udp"
+    command: -e 'input { gelf { host => "0.0.0.0" port => 12201 } }
+              output { elasticsearch { hosts => ["elasticsearch"] } }'
+    links:
+      - elasticsearch
+    depends_on:
+      - elasticsearch
+  kibana:
+    image: kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+    links:
+      - elasticsearch
+      - logstash
+    depends_on:
+      - logstash
   inventory-microservice:
     image: vertx-blueprint/inventory-microservice
     links:
       - redis
+      - logstash
     depends_on:
       - redis
+      - logstash
     expose:
       - "8086"
   product-microservice:
     image: vertx-blueprint/product-microservice
     links:
       - mysql
+      - logstash
     depends_on:
       - mysql
+      - logstash
     expose:
       - "8082"
   account-microservice:
     image: vertx-blueprint/account-microservice
     links:
       - mysql
+      - logstash
     depends_on:
       - mysql
+      - logstash
     expose:
       - "8081"
   store-microservice:
     image: vertx-blueprint/store-microservice
     links:
       - mongo
+      - logstash
     depends_on:
       - mongo
+      - logstash
     expose:
       - "8085"
   cache-infrastructure:
     image: vertx-blueprint/cache-infrastructure
     links:
       - redis
+      - logstash
     depends_on:
       - redis
+      - logstash
   shopping-cart-microservice:
     image: vertx-blueprint/shopping-cart-microservice
     links:
       - mysql
+      - logstash
       - inventory-microservice
       - product-microservice
       - cache-infrastructure
     depends_on:
       - mysql
+      - logstash
     expose:
       - "8084"
   order-microservice:
     image: vertx-blueprint/order-microservice
     links:
       - mysql
+      - logstash
     depends_on:
       - mysql
+      - logstash
       - shopping-cart-microservice
       - inventory-microservice
     expose:
@@ -85,10 +128,16 @@ services:
     image: vertx-blueprint/monitor-dashboard
     ports:
       - "9100:9100"
+    links:
+      - logstash
+    depends_on:
+      - logstash
   api-gateway:
     image: vertx-blueprint/api-gateway
     ports:
       - "8787:8787"
+    environment:
+      - JAVA_OPTS="-Xms128m -Xmx256m"
     links:
       - keycloak-server
       - inventory-microservice
@@ -97,5 +146,6 @@ services:
       - order-microservice
       - account-microservice
       - store-microservice
+      - logstash
     extra_hosts:
       - "dockernet:${EXTERNAL_IP}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,16 @@
+# The following might be required if using docker-machine:
+# docker-machine ssh
+# sudo sysctl net.ipv4.ip_forward; sudo sysctl -w vm.max_map_count=262144
+# add "192.168.99.100   dockernet" to /etc/hosts
+
 version: "2"
 services:
+  configserver:
+    image: httpd:alpine
+    ports:
+      - "8000:80"
+    volumes:
+      - ${DIR}/config-server:/usr/local/apache2/htdocs:ro
   mysql:
     image: mysql:5.7
     expose:
@@ -54,13 +65,17 @@ services:
   inventory-microservice:
     image: vertx-blueprint/inventory-microservice
     links:
+      - configserver
       - redis
       - logstash
     depends_on:
+      - configserver
       - redis
       - logstash
-    expose:
-      - "8086"
+#    expose:
+#      - "8086"
+    ports:
+      - "8086:8086"
   product-microservice:
     image: vertx-blueprint/product-microservice
     links:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,7 +22,7 @@ docker-compose -f $DIR/docker-compose.yml stop
 
 # Start container cluster
 # First start persistence and auth container and wait for it
-docker-compose -f $DIR/docker-compose.yml up -d mysql mongo redis keycloak-server
+docker-compose -f $DIR/docker-compose.yml up -d elasticsearch logstash kibana mysql mongo redis keycloak-server
 echo "Waiting for persistence init..."
 sleep 30
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,7 +15,7 @@ fi
 export EXTERNAL_IP=$IP
 
 # Get this script directory (to find yml from any directory)
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Stop
 docker-compose -f $DIR/docker-compose.yml stop

--- a/inventory-microservice/Dockerfile
+++ b/inventory-microservice/Dockerfile
@@ -13,4 +13,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar inventory-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar inventory-microservice-fat.jar -cluster -conf docker.json"]

--- a/inventory-microservice/Dockerfile
+++ b/inventory-microservice/Dockerfile
@@ -13,4 +13,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar inventory-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.disableDnsResolver=true -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar inventory-microservice-fat.jar -cluster -conf docker.json"]

--- a/inventory-microservice/pom.xml
+++ b/inventory-microservice/pom.xml
@@ -30,6 +30,12 @@
     </dependency>
 
     <dependency>
+      <groupId>me.escoffier.vertx</groupId>
+      <artifactId>vertx-configuration</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.kstyrc</groupId>
       <artifactId>embedded-redis</artifactId>
       <version>0.6</version>

--- a/inventory-microservice/src/main/java/io/vertx/blueprint/microservice/inventory/InventoryRestAPIVerticle.java
+++ b/inventory-microservice/src/main/java/io/vertx/blueprint/microservice/inventory/InventoryRestAPIVerticle.java
@@ -2,16 +2,17 @@ package io.vertx.blueprint.microservice.inventory;
 
 import io.vertx.blueprint.microservice.common.RestAPIVerticle;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.apache.logging.log4j.core.LoggerContext;
+import rx.Observable;
 
 import static io.vertx.blueprint.microservice.common.config.ConfigurationServiceHelper.configurationService;
-import static io.vertx.blueprint.microservice.common.config.Log4jConfigurationServiceHandler.log4jInitHandler;
-import static io.vertx.blueprint.microservice.common.config.Log4jConfigurationServiceHandler.log4jUpdateHandler;
+import static io.vertx.blueprint.microservice.common.config.Log4jConfigurationServiceHandler.log4jSubscriber;
 
 /**
  * A verticle supplies HTTP endpoint for inventory service API.
@@ -31,7 +32,6 @@ public class InventoryRestAPIVerticle extends RestAPIVerticle {
   private static final long SCAN_PERIOD = 20000L;
 
   private InventoryService inventoryService;
-  private LoggerContext loggerCtx;
 
   @Override
   public void start(Future<Void> future) throws Exception {
@@ -40,8 +40,8 @@ public class InventoryRestAPIVerticle extends RestAPIVerticle {
     configurationService
       .usingScanPeriod(SCAN_PERIOD)
       .withHttpStore("configserver", 80, "/inventory-microservice/docker.json")
-      .withHandlers(log4jInitHandler, log4jUpdateHandler)
-      .start(vertx, context);
+      .createConfigObservable(vertx)
+      .subscribe(log4jSubscriber);
 
     this.inventoryService = InventoryService.createService(vertx, config());
 

--- a/inventory-microservice/src/main/resources/log4j2.xml
+++ b/inventory-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="inventory-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/inventory-microservice/src/main/resources/log4j2.xml
+++ b/inventory-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="inventory-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/microservice-blueprint-common/pom.xml
+++ b/microservice-blueprint-common/pom.xml
@@ -29,6 +29,12 @@
       <version>6.0.3</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>me.escoffier.vertx</groupId>
+      <artifactId>vertx-configuration</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
@@ -1,0 +1,82 @@
+package io.vertx.blueprint.microservice.common.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.configuration.ConfigurationService;
+import io.vertx.ext.configuration.ConfigurationServiceOptions;
+import io.vertx.ext.configuration.ConfigurationStoreOptions;
+
+import static io.vertx.ext.configuration.ConfigurationService.create;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+
+public enum ConfigurationServiceHelper {
+    configurationService;
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigurationServiceHelper.class);
+
+    private ConfigurationService confSvc;
+    private ConfigurationServiceOptions options = new ConfigurationServiceOptions();
+    private List<ConfigurationServiceInitHandler> initializers = new ArrayList<>();
+    private List<ConfigurationServiceUpdateHandler> updaters = new ArrayList<>();
+
+    public ConfigurationServiceHelper usingScanPeriod(final long scanPeriod) {
+        options.setScanPeriod(scanPeriod);
+        return this;
+    }
+
+    public ConfigurationServiceHelper start(final Vertx vertx, final Context context) {
+        confSvc = create(vertx, options);
+
+        confSvc.getConfiguration(ar -> {
+            if (ar.failed()) {
+                logger.info("Failed to retrieve configuration...");
+            } else {
+                final JsonObject config =
+                  context.config().mergeIn(ofNullable(ar.result()).orElse(new JsonObject()));
+                initializers.forEach(initializer -> initializer.initialize(config));
+            }
+        });
+
+        confSvc.listen(ar -> {
+            final JsonObject config =
+              context.config().mergeIn(ofNullable(ar.getNewConfiguration()).orElse(new JsonObject()));
+            updaters.forEach(updater -> updater.update(config));
+        });
+        return this;
+    }
+
+    public ConfigurationServiceHelper withHttpStore(final String host, final int port, final String path) {
+        ConfigurationStoreOptions httpStore = new ConfigurationStoreOptions()
+          .setType("http")
+          .setConfig(new JsonObject()
+            .put("host", host).put("port", port).put("path", path));
+
+        options.addStore(httpStore);
+        return this;
+    }
+
+    public ConfigurationServiceHelper withInitializer(final ConfigurationServiceInitHandler initializer) {
+        requireNonNull(initializer);
+        initializers.add(initializer);
+        return this;
+    }
+
+    public ConfigurationServiceHelper withUpdater(final ConfigurationServiceUpdateHandler updater) {
+        requireNonNull(updater);
+        updaters.add(updater);
+        return this;
+    }
+
+    public ConfigurationServiceHelper withHandlers(final ConfigurationServiceInitHandler initializer,
+                                                   final ConfigurationServiceUpdateHandler updater) {
+        withInitializer(initializer);
+        return withUpdater(updater);
+    }
+}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
@@ -31,7 +31,7 @@ public enum ConfigurationServiceHelper {
     return this;
   }
 
-  public ConfigurationServiceHelper start(final Vertx vertx, final Context context) {
+  public ConfigurationServiceHelper start(final Vertx vertx) {
     confSvc = create(vertx, options);
 
     confSvc.getConfiguration(ar -> {
@@ -39,14 +39,14 @@ public enum ConfigurationServiceHelper {
         logger.info("Failed to retrieve configuration...");
       } else {
         final JsonObject config =
-          context.config().mergeIn(ofNullable(ar.result()).orElse(new JsonObject()));
+          vertx.getOrCreateContext().config().mergeIn(ofNullable(ar.result()).orElse(new JsonObject()));
         initializers.forEach(initializer -> initializer.initialize(config));
       }
     });
 
     confSvc.listen(ar -> {
       final JsonObject config =
-        context.config().mergeIn(ofNullable(ar.getNewConfiguration()).orElse(new JsonObject()));
+        vertx.getOrCreateContext().config().mergeIn(ofNullable(ar.getNewConfiguration()).orElse(new JsonObject()));
       updaters.forEach(updater -> updater.update(config));
     });
     return this;

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceHelper.java
@@ -17,66 +17,66 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
 public enum ConfigurationServiceHelper {
-    configurationService;
+  configurationService;
 
-    private static final Logger logger = LoggerFactory.getLogger(ConfigurationServiceHelper.class);
+  private static final Logger logger = LoggerFactory.getLogger(ConfigurationServiceHelper.class);
 
-    private ConfigurationService confSvc;
-    private ConfigurationServiceOptions options = new ConfigurationServiceOptions();
-    private List<ConfigurationServiceInitHandler> initializers = new ArrayList<>();
-    private List<ConfigurationServiceUpdateHandler> updaters = new ArrayList<>();
+  private ConfigurationService confSvc;
+  private ConfigurationServiceOptions options = new ConfigurationServiceOptions();
+  private List<ConfigurationServiceInitHandler> initializers = new ArrayList<>();
+  private List<ConfigurationServiceUpdateHandler> updaters = new ArrayList<>();
 
-    public ConfigurationServiceHelper usingScanPeriod(final long scanPeriod) {
-        options.setScanPeriod(scanPeriod);
-        return this;
-    }
+  public ConfigurationServiceHelper usingScanPeriod(final long scanPeriod) {
+    options.setScanPeriod(scanPeriod);
+    return this;
+  }
 
-    public ConfigurationServiceHelper start(final Vertx vertx, final Context context) {
-        confSvc = create(vertx, options);
+  public ConfigurationServiceHelper start(final Vertx vertx, final Context context) {
+    confSvc = create(vertx, options);
 
-        confSvc.getConfiguration(ar -> {
-            if (ar.failed()) {
-                logger.info("Failed to retrieve configuration...");
-            } else {
-                final JsonObject config =
-                  context.config().mergeIn(ofNullable(ar.result()).orElse(new JsonObject()));
-                initializers.forEach(initializer -> initializer.initialize(config));
-            }
-        });
+    confSvc.getConfiguration(ar -> {
+      if (ar.failed()) {
+        logger.info("Failed to retrieve configuration...");
+      } else {
+        final JsonObject config =
+          context.config().mergeIn(ofNullable(ar.result()).orElse(new JsonObject()));
+        initializers.forEach(initializer -> initializer.initialize(config));
+      }
+    });
 
-        confSvc.listen(ar -> {
-            final JsonObject config =
-              context.config().mergeIn(ofNullable(ar.getNewConfiguration()).orElse(new JsonObject()));
-            updaters.forEach(updater -> updater.update(config));
-        });
-        return this;
-    }
+    confSvc.listen(ar -> {
+      final JsonObject config =
+        context.config().mergeIn(ofNullable(ar.getNewConfiguration()).orElse(new JsonObject()));
+      updaters.forEach(updater -> updater.update(config));
+    });
+    return this;
+  }
 
-    public ConfigurationServiceHelper withHttpStore(final String host, final int port, final String path) {
-        ConfigurationStoreOptions httpStore = new ConfigurationStoreOptions()
-          .setType("http")
-          .setConfig(new JsonObject()
-            .put("host", host).put("port", port).put("path", path));
+  public ConfigurationServiceHelper withHttpStore(final String host, final int port, final String path) {
+    ConfigurationStoreOptions httpStore = new ConfigurationStoreOptions()
+      .setType("http")
+      .setConfig(new JsonObject()
+        .put("host", host).put("port", port).put("path", path));
 
-        options.addStore(httpStore);
-        return this;
-    }
+    options.addStore(httpStore);
+    return this;
+  }
 
-    public ConfigurationServiceHelper withInitializer(final ConfigurationServiceInitHandler initializer) {
-        requireNonNull(initializer);
-        initializers.add(initializer);
-        return this;
-    }
+  public ConfigurationServiceHelper withInitializer(final ConfigurationServiceInitHandler initializer) {
+    requireNonNull(initializer);
+    initializers.add(initializer);
+    return this;
+  }
 
-    public ConfigurationServiceHelper withUpdater(final ConfigurationServiceUpdateHandler updater) {
-        requireNonNull(updater);
-        updaters.add(updater);
-        return this;
-    }
+  public ConfigurationServiceHelper withUpdater(final ConfigurationServiceUpdateHandler updater) {
+    requireNonNull(updater);
+    updaters.add(updater);
+    return this;
+  }
 
-    public ConfigurationServiceHelper withHandlers(final ConfigurationServiceInitHandler initializer,
-                                                   final ConfigurationServiceUpdateHandler updater) {
-        withInitializer(initializer);
-        return withUpdater(updater);
-    }
+  public ConfigurationServiceHelper withHandlers(final ConfigurationServiceInitHandler initializer,
+                                                 final ConfigurationServiceUpdateHandler updater) {
+    withInitializer(initializer);
+    return withUpdater(updater);
+  }
 }

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
@@ -1,0 +1,8 @@
+package io.vertx.blueprint.microservice.common.config;
+
+import io.vertx.core.json.JsonObject;
+
+@FunctionalInterface
+public interface ConfigurationServiceInitHandler {
+    void initialize(final JsonObject config);
+}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
@@ -1,8 +1,0 @@
-package io.vertx.blueprint.microservice.common.config;
-
-import io.vertx.core.json.JsonObject;
-
-@FunctionalInterface
-public interface ConfigurationServiceInitHandler {
-  void initialize(final JsonObject config);
-}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceInitHandler.java
@@ -4,5 +4,5 @@ import io.vertx.core.json.JsonObject;
 
 @FunctionalInterface
 public interface ConfigurationServiceInitHandler {
-    void initialize(final JsonObject config);
+  void initialize(final JsonObject config);
 }

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
@@ -1,8 +1,0 @@
-package io.vertx.blueprint.microservice.common.config;
-
-import io.vertx.core.json.JsonObject;
-
-@FunctionalInterface
-public interface ConfigurationServiceUpdateHandler {
-  void update(final JsonObject config);
-}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
@@ -1,0 +1,8 @@
+package io.vertx.blueprint.microservice.common.config;
+
+import io.vertx.core.json.JsonObject;
+
+@FunctionalInterface
+public interface ConfigurationServiceUpdateHandler {
+    void update(final JsonObject config);
+}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/ConfigurationServiceUpdateHandler.java
@@ -4,5 +4,5 @@ import io.vertx.core.json.JsonObject;
 
 @FunctionalInterface
 public interface ConfigurationServiceUpdateHandler {
-    void update(final JsonObject config);
+  void update(final JsonObject config);
 }

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
@@ -9,18 +9,18 @@ import org.apache.logging.log4j.core.config.Configurator;
 
 public class Log4jConfigurationServiceHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(Log4jConfigurationServiceHandler.class);
-    private static LoggerContext loggerCtx;
+  private static final Logger logger = LoggerFactory.getLogger(Log4jConfigurationServiceHandler.class);
+  private static LoggerContext loggerCtx;
 
-    public static ConfigurationServiceInitHandler log4jInitHandler = config -> {
-        loggerCtx = Configurator.initialize(null, config.getString("log4j.config.uri", "log4j2.xml"));
-    };
+  public static ConfigurationServiceInitHandler log4jInitHandler = config -> {
+    loggerCtx = Configurator.initialize(null, config.getString("log4j.config.uri", "log4j2.xml"));
+  };
 
-    public static ConfigurationServiceUpdateHandler log4jUpdateHandler = config -> {
-        try {
-            loggerCtx.setConfigLocation(new URI(config.getString("log4j.config.uri", "log4j2.xml")));
-        } catch (final Exception e) {
-            logger.error(e);
-        }
-    };
+  public static ConfigurationServiceUpdateHandler log4jUpdateHandler = config -> {
+    try {
+      loggerCtx.setConfigLocation(new URI(config.getString("log4j.config.uri", "log4j2.xml")));
+    } catch (final Exception e) {
+      logger.error(e);
+    }
+  };
 }

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
@@ -1,0 +1,26 @@
+package io.vertx.blueprint.microservice.common.config;
+
+import java.net.URI;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+
+public class Log4jConfigurationServiceHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(Log4jConfigurationServiceHandler.class);
+    private static LoggerContext loggerCtx;
+
+    public static ConfigurationServiceInitHandler log4jInitHandler = config -> {
+        loggerCtx = Configurator.initialize(null, config.getString("log4j.config.uri", "log4j2.xml"));
+    };
+
+    public static ConfigurationServiceUpdateHandler log4jUpdateHandler = config -> {
+        try {
+            loggerCtx.setConfigLocation(new URI(config.getString("log4j.config.uri", "log4j2.xml")));
+        } catch (final Exception e) {
+            logger.error(e);
+        }
+    };
+}

--- a/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
+++ b/microservice-blueprint-common/src/main/java/io/vertx/blueprint/microservice/common/config/Log4jConfigurationServiceHandler.java
@@ -2,25 +2,41 @@ package io.vertx.blueprint.microservice.common.config;
 
 import java.net.URI;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configurator;
+import rx.functions.Action1;
+
+import static java.util.Objects.isNull;
+import static org.apache.logging.log4j.core.config.Configurator.initialize;
 
 public class Log4jConfigurationServiceHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(Log4jConfigurationServiceHandler.class);
   private static LoggerContext loggerCtx;
 
-  public static ConfigurationServiceInitHandler log4jInitHandler = config -> {
-    loggerCtx = Configurator.initialize(null, config.getString("log4j.config.uri", "log4j2.xml"));
+  public static Action1<JsonObject> log4jSubscriber = config -> {
+    if (isNull(loggerCtx)) {
+      initLoggerContext(config);
+    } else {
+      updateLoggerContext(config);
+    }
   };
 
-  public static ConfigurationServiceUpdateHandler log4jUpdateHandler = config -> {
+  private static LoggerContext initLoggerContext(final JsonObject config) {
+    return loggerCtx = initialize(null, getLog4jConfigUri(config));
+  }
+
+  private static void updateLoggerContext(final JsonObject config) {
     try {
-      loggerCtx.setConfigLocation(new URI(config.getString("log4j.config.uri", "log4j2.xml")));
+      loggerCtx.setConfigLocation(new URI(getLog4jConfigUri(config)));
     } catch (final Exception e) {
       logger.error(e);
     }
-  };
+  }
+
+  private static String getLog4jConfigUri(final JsonObject config) {
+    return config.getString("log4j.config.uri", "log4j2.xml");
+  }
 }

--- a/monitor-dashboard/Dockerfile
+++ b/monitor-dashboard/Dockerfile
@@ -12,4 +12,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar monitor-dashboard-fat.jar -Dvertx.metrics.options.enabled=true -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar monitor-dashboard-fat.jar -Dvertx.metrics.options.enabled=true -cluster -conf docker.json"]

--- a/monitor-dashboard/src/main/resources/log4j2.xml
+++ b/monitor-dashboard/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="monitor-dashboard"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/monitor-dashboard/src/main/resources/log4j2.xml
+++ b/monitor-dashboard/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="monitor-dashboard"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/order-microservice/Dockerfile
+++ b/order-microservice/Dockerfile
@@ -13,4 +13,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar order-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar order-microservice-fat.jar -cluster -conf docker.json"]

--- a/order-microservice/src/main/resources/log4j2.xml
+++ b/order-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="order-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/order-microservice/src/main/resources/log4j2.xml
+++ b/order-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="order-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/payment-microservice/src/main/resources/log4j2.xml
+++ b/payment-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="payment-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/payment-microservice/src/main/resources/log4j2.xml
+++ b/payment-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="payment-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,32 @@
       <artifactId>vertx-circuit-breaker</artifactId>
     </dependency>
 
+    <!-- Logging dependencies -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>biz.paluch.logging</groupId>
+      <artifactId>logstash-gelf</artifactId>
+      <version>1.11.0</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -235,4 +235,13 @@
     </pluginManagement>
   </build>
 
+  <repositories>
+    <repository>
+      <id>snapshots-repo</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases><enabled>false</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
+
 </project>

--- a/product-microservice/Dockerfile
+++ b/product-microservice/Dockerfile
@@ -12,4 +12,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar product-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar product-microservice-fat.jar -cluster -conf docker.json"]

--- a/product-microservice/src/main/resources/log4j2.xml
+++ b/product-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="product-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/product-microservice/src/main/resources/log4j2.xml
+++ b/product-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="product-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/shopping-cart-microservice/Dockerfile
+++ b/shopping-cart-microservice/Dockerfile
@@ -12,4 +12,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar shopping-cart-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar shopping-cart-microservice-fat.jar -cluster -conf docker.json"]

--- a/shopping-cart-microservice/src/main/resources/log4j2.xml
+++ b/shopping-cart-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="shopping-cart-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/shopping-cart-microservice/src/main/resources/log4j2.xml
+++ b/shopping-cart-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="shopping-cart-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/shopping-ui/Dockerfile
+++ b/shopping-ui/Dockerfile
@@ -12,4 +12,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar shopping-ui-fat.jar -Dvertx.metrics.options.enabled=true -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar shopping-ui-fat.jar -Dvertx.metrics.options.enabled=true -cluster -conf docker.json"]

--- a/shopping-ui/src/main/resources/log4j2.xml
+++ b/shopping-ui/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="shopping-ui"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/shopping-ui/src/main/resources/log4j2.xml
+++ b/shopping-ui/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="shopping-ui"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/store-microservice/Dockerfile
+++ b/store-microservice/Dockerfile
@@ -12,4 +12,4 @@ COPY src/config/docker.json $VERTICLE_HOME/
 
 WORKDIR $VERTICLE_HOME
 ENTRYPOINT ["sh", "-c"]
-CMD ["java -jar store-microservice-fat.jar -cluster -conf docker.json"]
+CMD ["java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -jar store-microservice-fat.jar -cluster -conf docker.json"]

--- a/store-microservice/src/main/resources/log4j2.xml
+++ b/store-microservice/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error" packages="biz.paluch.logging.gelf.log4j2">
+    <Appenders>
+
+        <!--<Console name="console" target="SYSTEM_OUT">-->
+        <!--<PatternLayout pattern="%d{dd.MM.yyyy HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>-->
+        <!--</Console>-->
+
+        <Gelf name="gelf" host="udp:logstash" port="12201">
+            <Field name="level" pattern="%level"/>
+            <Field name="facility" literal="store-microservice"/>
+        </Gelf>
+
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <!--<AppenderRef ref="console"/>-->
+            <AppenderRef ref="gelf"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/store-microservice/src/main/resources/log4j2.xml
+++ b/store-microservice/src/main/resources/log4j2.xml
@@ -11,11 +11,15 @@
             <Field name="facility" literal="store-microservice"/>
         </Gelf>
 
+        <Async name="gelf_async">
+            <AppenderRef ref="gelf"/>
+        </Async>
+
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <!--<AppenderRef ref="console"/>-->
-            <AppenderRef ref="gelf"/>
+            <AppenderRef ref="gelf_async"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Introduce simple dynamic configuration server and client.

This is an initial solution that uses @cescoffier [vertx-configuration](https://github.com/cescoffier/vertx-configuration-service/blob/master/vertx-configuration/src/main/asciidoc/java/index.adoc)

It adds a simple singleton based solution to facilitate the configuration of specialized handlers every-time there is a configuration initialization or update. I've added a Log4j configuration service handler as an example.

Issue #9